### PR TITLE
implemented the free stack in read_file and exec_cmd_args

### DIFF
--- a/free_stack.c
+++ b/free_stack.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include "monty.h"
+
+/**
+ * free_stack - Function to free the stack
+ *
+ * Return: void.
+ */
+
+void free_stack(void)
+{
+	stack_t *temp;
+
+	if (head == NULL)
+		return;
+	while (head->next)
+	{
+		temp = head->next;
+		free(head);
+		head = temp;
+	}
+	free(head);
+}

--- a/linetest/test
+++ b/linetest/test
@@ -1,4 +1,4 @@
-			push 1			
+			push 4			
        		push 2		
 
 push 3	
@@ -6,3 +6,10 @@ push 3
 push 26
 
 pall
+
+pop
+pop
+pop
+pop
+pop
+pop

--- a/linetest/test4
+++ b/linetest/test4
@@ -1,3 +1,4 @@
 push 0
 push 1
 push 3
+pall

--- a/monty.h
+++ b/monty.h
@@ -60,4 +60,6 @@ stack_t *get_node(int val);
 void pop(stack_t **stack, unsigned int line_number);
 void exec_cmd_args(char **tokens, int line_number);
 void exec_cmd_noarg(char **tokens, int line_number);
+void free_stack(void);
+
 #endif

--- a/read_file.c
+++ b/read_file.c
@@ -41,6 +41,7 @@ void read_file(char *buff, int n, char *file_path)
 		}
 		line_number++;
 	}
+	free_stack();
 	fclose(file_ptr);
 }
 /**
@@ -66,6 +67,7 @@ void exec_cmd_args(char **tokens, int line_number)
 		{
 			fprintf(stderr, "L%d: usage: push integer\n", line_number);
 			free(tokens);
+			free_stack();
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -92,6 +94,7 @@ void exec_cmd_noarg(char **tokens, int line_number)
 	{
 		fprintf(stderr, "L%d: unknown instruction %s\n", line_number, tokens[0]);
 		free(tokens);
+		free_stack();
 		exit(EXIT_FAILURE);
 	}
 	free(tokens);


### PR DESCRIPTION
The free stack finds major use when the entire program is successful.
It also finds use when the push fails.
It also finds use when we encounter an invalid instruction. `opcode == NULL`
Thus it was implemented int those three use-cases.

On other cases, like when we are using pint, the condition from exiting them is when `head==NULL`, in which obvious case, the stack is empty.